### PR TITLE
chore: add monthly Nix Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Configure Dependabot to update Nix inputs monthly. This does not change any existing flake lockfile pins.