### PR TITLE
chore: align Dependabot update schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: cargo
     directory: /
     schedule:


### PR DESCRIPTION
Align Dependabot schedules with the repository baseline.

This changes only `.github/dependabot.yml`; it does not update Cargo.lock or Nix input hashes.
